### PR TITLE
add containerHeight prop

### DIFF
--- a/src/AutoRotatingCarousel.js
+++ b/src/AutoRotatingCarousel.js
@@ -141,6 +141,7 @@ class AutoRotatingCarousel extends Component {
       autoplay,
       children,
       classes,
+      containerHeight,
       hideArrows,
       interval,
       label,
@@ -157,7 +158,7 @@ class AutoRotatingCarousel extends Component {
       <Carousel
         autoplay={open && autoplay}
         className={classes.carousel}
-        containerStyle={{ height: '100%' }}
+        containerStyle={{ height: containerHeight || '100%' }}
         index={this.state.slideIndex}
         interval={interval}
         onChangeIndex={this.handleChange}


### PR DESCRIPTION
To make the height of the carousel easier to change. It will still take up the entire window if there is no `containerHeight` prop specified.
closes #38