### PR TITLE
Add support for modal backdrop flag and container object

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,19 @@ npm i --save react-swipeable-views
 
 ### AutoRotatingCarousel Properties
 
-|Name            |Type        |Default     |Description
-|----------------|------------|------------|--------------------------------
-|autoplay        | `bool`     | `true`     | If `false`, the auto play behavior is disabled.
-|interval        | `integer`  | `3000`     | Delay between auto play transitions (in ms).
-|label           | `string`   |            | Button text. If not supplied, the button will be hidden.
-|landscape       | `bool`     |            | If `true`, slide will adjust content for wide mobile screens.
-|mobile          | `bool`     | `false`    | If `true`, the screen width and height is filled.
-|open            | `bool`     | `false`    | Controls whether the AutoRotatingCarousel is opened or not.
-|onChange        | `function` |            | Fired when the index changed. Returns current index.
-|onClose         | `function` |            | Fired when the gray background of the popup is pressed when it is open.
-|onStart         | `function` |            | Fired when the user clicks the getting started button.
+|Name            |Type                        |Default     |Description
+|----------------|----------------------------|------------|--------------------------------
+|autoplay        | `bool`                     | `true`     | If `false`, the auto play behavior is disabled.
+|interval        | `integer`                  | `3000`     | Delay between auto play transitions (in ms).
+|label           | `string`                   |            | Button text. If not supplied, the button will be hidden.
+|landscape       | `bool`                     |            | If `true`, slide will adjust content for wide mobile screens.
+|mobile          | `bool`                     | `false`    | If `true`, the screen width and height is filled.
+|open            | `bool`                     | `false`    | Controls whether the AutoRotatingCarousel is opened or not.
+|onChange        | `function`                 |            | Fired when the index changed. Returns current index.
+|onClose         | `function`                 |            | Fired when the gray background of the popup is pressed when it is open.
+|onStart         | `function`                 |            | Fired when the user clicks the getting started button.
+|hideBackdrop    | `bool`                     | `false`    | Controls the modal's backdrop.
+|container       | `Dom Object` || `function` | `root`     | Specify the container for the modal.
 
 ### Slide Properties
 

--- a/src/AutoRotatingCarousel.js
+++ b/src/AutoRotatingCarousel.js
@@ -142,6 +142,8 @@ class AutoRotatingCarousel extends Component {
       children,
       classes,
       hideArrows,
+      hideBackdrop,
+      container,
       interval,
       label,
       landscape: landscapeProp,
@@ -179,6 +181,8 @@ class AutoRotatingCarousel extends Component {
         open={open}
         onClose={onClose}
         BackdropProps={{ transitionDuration }}
+        hideBackdrop={hideBackdrop}
+        container={container}
       >
         <Fade
           appear
@@ -250,7 +254,8 @@ AutoRotatingCarousel.defaultProps = {
   interval: 3000,
   mobile: false,
   open: false,
-  hideArrows: false
+  hideArrows: false,
+  hideBackdrop: false
 }
 
 AutoRotatingCarousel.propTypes = {
@@ -275,7 +280,14 @@ AutoRotatingCarousel.propTypes = {
   /** Controls whether the AutoRotatingCarousel is opened or not. */
   open: PropTypes.bool,
   /** If `true`, the left and right arrows are hidden in the desktop version. */
-  hideArrows: PropTypes.bool
+  hideArrows: PropTypes.bool,
+  /** Controls the modal's backdrop. */
+  hideBackdrop: PropTypes.bool,
+  /** Specify the container for the modal. Allowing you to embed the carousel in components instead of root */
+  container: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.func,
+  ])
 }
 
 export default withStyles(styles)(AutoRotatingCarousel)


### PR DESCRIPTION
Addresses issue #38 

The `containerStyle` is fine. The issue was with the new material-ui modal. Exposed the hideBackdrop and container props so it can be customized easier and allow embedding of the carousel in any component.