### PR TITLE
Add BackdropComponent prop to resolve issue with transitionDuration prop on MUI v4

### DIFF
--- a/src/AutoRotatingCarousel.js
+++ b/src/AutoRotatingCarousel.js
@@ -10,6 +10,7 @@ import ArrowBackIcon from '@material-ui/icons/ArrowBack'
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward'
 import Modal from '@material-ui/core/Modal'
 import Fade from '@material-ui/core/Fade'
+import Backdrop from '@material-ui/core/Backdrop'
 import Dots from 'material-ui-dots'
 import classNames from 'classnames'
 import Carousel from './SwipableCarouselView'
@@ -188,6 +189,7 @@ class AutoRotatingCarousel extends Component {
         })}
         open={open}
         onClose={onClose}
+        BackdropComponent={Backdrop}
         BackdropProps={ModalProps ? { transitionDuration, ...ModalProps.BackdropProps } : { transitionDuration }}
         {...ModalProps}
       >


### PR DESCRIPTION
In Material UI v3 the modal uses the Backdrop component which supports transitionDuration. 
In Material UI v4 the modal uses a 'SimpleBackdrop' component with limited prop support.

This change forces the Modal to use the Backdrop component. This will make no visual or behavioural difference in MUI v3 and enables support for transitionDuration in MUI v4.

Fixes #66 